### PR TITLE
Correct path to Plugins directory on Mac

### DIFF
--- a/listplugins/__init__.py
+++ b/listplugins/__init__.py
@@ -10,7 +10,7 @@ class ListPlugins(DirectoryPaneCommand):
         elif platform.system() == "Linux":
             appdata = path.expanduser("~") + "/.config"
         elif platform.system() == "Darwin":
-            appdata = path.expanduser("~") + "/Library/Application Support/fman"
+            appdata = path.expanduser("~") + "/Library/Application Support"
 
         plugin_dir = glob.glob(appdata + "/fman/Plugins/*")
         plugin_amount = 0


### PR DESCRIPTION
Hey Kim,

I believe there was a little bug in `ListPlugins` on Mac, because it always displayed "0 plugins" there. This PR fixes it. The bug was actually reported to me by another fman user :-)

Cheers!
Michael